### PR TITLE
Add missing JSDoc namespaces.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,18 @@
 /**
  * @namespace google.cloud.iot.v1
  */
+/**
+ * @namespace google.iam
+ */
+/**
+ * @namespace google.iam.v1
+ */
+/**
+ * @namespace google.protobuf
+ */
+/**
+ * @namespace google.rpc
+ */
 
 'use strict';
 


### PR DESCRIPTION
A new patch release needs to be cut for these changes to be able to fix the generated JSDocs.