### PR TITLE
chore: remove obsolete replacements from synth.py

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -51,16 +51,6 @@ s.replace("src/v1/doc/google/cloud/iot/v1/doc_resources.js",
         "\[RFC(.*)\]\(https:\/\/cloud\.google\.com",
         r"[RFC\1](")
 
-# [START fix-dead-link]
-s.replace('**/doc/google/protobuf/doc_timestamp.js',
-        'https:\/\/cloud\.google\.com[\s\*]*http:\/\/(.*)[\s\*]*\)',
-        r"https://\1)")
-
-s.replace('**/doc/google/protobuf/doc_timestamp.js',
-        'toISOString\]',
-        'toISOString)')
-
-# [END fix-dead-link]
 # Node.js specific cleanup
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'fix'])


### PR DESCRIPTION
No docs, no replacements needed.

```
2020-03-05 14:27:48,958 synthtool > No replacements made in src/v1/doc/google/cloud/iot/v1/doc_resources.js for pattern \[RFC(.*)\]\(https:\/\/cloud\.google\.com, maybe replacement is no longer needed?
2020-03-05 14:27:49,016 synthtool > No replacements made in **/doc/google/protobuf/doc_timestamp.js for pattern https:\/\/cloud\.google\.com[\s\*]*http:\/\/(.*)[\s\*]*\), maybe replacement is no longer needed?
2020-03-05 14:27:49,035 synthtool > No replacements made in **/doc/google/protobuf/doc_timestamp.js for pattern toISOString\], maybe replacement is no longer needed?
```
