### PR TITLE
refactor: clean up sample test structure

### DIFF
--- a/samples/.eslintrc.yml
+++ b/samples/.eslintrc.yml
@@ -1,4 +1,3 @@
 ---
 rules:
   no-console: off
-  node/no-missing-require: off

--- a/samples/http_example/package.json
+++ b/samples/http_example/package.json
@@ -5,25 +5,27 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "main": "cloudiot_http_example_nodejs.js",
+  "files": [
+    "*.js"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
+    "url": "https://github.com/googleapis/nodejs-iot.git"
   },
   "engines": {
     "node": ">=10.0.0"
   },
   "scripts": {
-    "test": "mocha system-test/*.test.js --timeout=60000",
-    "system-test": "mocha system-test/*.test.js --timeout=60000"
+    "test": "mocha --timeout=60000"
   },
   "dependencies": {
+    "gaxios": "^3.1.0",
     "jsonwebtoken": "^8.5.0",
-    "mocha": "^8.0.0",
-    "request": "^2.88.0",
-    "retry-request": "^4.0.0",
-    "uuid": "^8.0.0",
-    "yargs": "^15.0.0",
+    "yargs": "^15.0.0"
+  },
+  "devDependencies": {
     "@google-cloud/pubsub": "^2.0.0",
-    "googleapis": "^56.0.0"
+    "mocha": "^8.1.1",
+    "uuid": "^8.0.0"
   }
 }

--- a/samples/http_example/test/cloudiot_http_example.test.js
+++ b/samples/http_example/test/cloudiot_http_example.test.js
@@ -17,21 +17,18 @@
 const {PubSub} = require('@google-cloud/pubsub');
 const assert = require('assert');
 const cp = require('child_process');
-const path = require('path');
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const uuid = require('uuid');
-
 const {after, before, it} = require('mocha');
 
 const deviceId = 'test-node-device';
 const topicName = `nodejs-docs-samples-test-iot-${uuid.v4()}`;
 const registryName = `nodejs-test-registry-iot-${uuid.v4()}`;
-const helper = 'node manager/manager.js';
-const cmd = `node http_example/cloudiot_http_example.js --registryId="${registryName}" --deviceId="${deviceId}" `;
-const cwd = path.join(__dirname, '..');
+const helper = 'node ../manager/manager.js';
+const cmd = `node cloudiot_http_example.js --registryId="${registryName}" --deviceId="${deviceId}" `;
 const installDeps = 'npm install';
 
-assert.ok(execSync(installDeps, `${cwd}/../manager`));
+assert.ok(execSync(installDeps, '../manager'));
 before(async () => {
   assert(
     process.env.GCLOUD_PROJECT,
@@ -57,77 +54,61 @@ it('should receive configuration message', async () => {
   const localDevice = 'test-rsa-device';
   const localRegName = `${registryName}-rsa256config`;
 
-  await execSync(`${helper} setupIotTopic ${topicName}`, cwd);
-  await execSync(`${helper} createRegistry ${localRegName} ${topicName}`, cwd);
+  await execSync(`${helper} setupIotTopic ${topicName}`);
+  await execSync(`${helper} createRegistry ${localRegName} ${topicName}`);
   await execSync(
-    `${helper} createRsa256Device ${localDevice} ${localRegName} resources/rsa_cert.pem`,
-    cwd
+    `${helper} createRsa256Device ${localDevice} ${localRegName} ../resources/rsa_cert.pem`
   );
-
   const output = await execSync(
-    `${cmd} --messageType=events --numMessages=1 --privateKeyFile=resources/rsa_private.pem --algorithm=RS256`,
-    cwd
+    `${cmd} --messageType=events --numMessages=1 --privateKeyFile=../resources/rsa_private.pem --algorithm=RS256`
   );
 
   assert.strictEqual(new RegExp(/Getting config/).test(output), true);
 
   // Check / cleanup
-  await execSync(
-    `${helper} getDeviceState ${localDevice} ${localRegName}`,
-    cwd
-  );
-  await execSync(`${helper} deleteDevice ${localDevice} ${localRegName}`, cwd);
-  await execSync(`${helper} deleteRegistry ${localRegName}`, cwd);
+  await execSync(`${helper} getDeviceState ${localDevice} ${localRegName}`);
+  await execSync(`${helper} deleteDevice ${localDevice} ${localRegName}`);
+  await execSync(`${helper} deleteRegistry ${localRegName}`);
 });
 
 it('should send event message', async () => {
   const localDevice = 'test-rsa-device';
   const localRegName = `${registryName}-rsa256`;
 
-  await execSync(`${helper} setupIotTopic ${topicName}`, cwd);
-  await execSync(`${helper} createRegistry ${localRegName} ${topicName}`, cwd);
+  await execSync(`${helper} setupIotTopic ${topicName}`);
+  await execSync(`${helper} createRegistry ${localRegName} ${topicName}`);
   await execSync(
-    `${helper} createRsa256Device ${localDevice} ${localRegName} resources/rsa_cert.pem`,
-    cwd
+    `${helper} createRsa256Device ${localDevice} ${localRegName} ../resources/rsa_cert.pem`
   );
 
   const output = await execSync(
-    `${cmd} --messageType=events --numMessages=1 --privateKeyFile=resources/rsa_private.pem --algorithm=RS256`,
-    cwd
+    `${cmd} --messageType=events --numMessages=1 --privateKeyFile=../resources/rsa_private.pem --algorithm=RS256`
   );
 
   assert.strictEqual(new RegExp(/Publishing message/).test(output), true);
 
   // Check / cleanup
-  await execSync(
-    `${helper} getDeviceState ${localDevice} ${localRegName}`,
-    cwd
-  );
-  await execSync(`${helper} deleteDevice ${localDevice} ${localRegName}`, cwd);
-  await execSync(`${helper} deleteRegistry ${localRegName}`, cwd);
+  await execSync(`${helper} getDeviceState ${localDevice} ${localRegName}`);
+  await execSync(`${helper} deleteDevice ${localDevice} ${localRegName}`);
+  await execSync(`${helper} deleteRegistry ${localRegName}`);
 });
 
 it('should send state message', async () => {
   const localDevice = 'test-rsa-device';
   const localRegName = `${registryName}-rsa256`;
-  await execSync(`${helper} setupIotTopic ${topicName}`, cwd);
-  await execSync(`${helper} createRegistry ${localRegName} ${topicName}`, cwd);
+  await execSync(`${helper} setupIotTopic ${topicName}`);
+  await execSync(`${helper} createRegistry ${localRegName} ${topicName}`);
   await execSync(
-    `${helper} createRsa256Device ${localDevice} ${localRegName} resources/rsa_cert.pem`,
-    cwd
+    `${helper} createRsa256Device ${localDevice} ${localRegName} ../resources/rsa_cert.pem`
   );
 
   const output = await execSync(
-    `${cmd} --messageType=state --numMessages=1 --privateKeyFile=resources/rsa_private.pem --algorithm=RS256`,
-    cwd
+    `${cmd} --messageType=state --numMessages=1 --privateKeyFile=../resources/rsa_private.pem --algorithm=RS256`
   );
   assert.strictEqual(new RegExp(/Publishing message/).test(output), true);
 
   // Check / cleanup
-  await execSync(
-    `${helper} getDeviceState ${localDevice} ${localRegName}`,
-    cwd
-  );
-  await execSync(`${helper} deleteDevice ${localDevice} ${localRegName}`, cwd);
-  await execSync(`${helper} deleteRegistry ${localRegName}`, cwd);
+  await execSync(`${helper} getDeviceState ${localDevice} ${localRegName}`);
+  await execSync(`${helper} deleteDevice ${localDevice} ${localRegName}`);
+  await execSync(`${helper} deleteRegistry ${localRegName}`);
 });

--- a/samples/manager/package.json
+++ b/samples/manager/package.json
@@ -5,6 +5,9 @@
   "main": "manager.js",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "files": [
+    "*.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
@@ -13,15 +16,15 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "test": "mocha system-test/*.test.js --timeout=600000",
-    "system-test": "mocha system-test/*.test.js --timeout=600000"
+    "test": "mocha --timeout=600000"
   },
   "dependencies": {
     "@google-cloud/iot": "^2.0.0",
     "@google-cloud/pubsub": "^2.0.0",
-    "googleapis": "^56.0.0",
-    "mocha": "^8.0.0",
-    "uuid": "^8.0.0",
     "yargs": "^15.1.0"
+  },
+  "devDependencies": {
+    "mocha": "^8.1.1",
+    "uuid": "^8.0.0"
   }
 }

--- a/samples/manager/test/manager.test.js
+++ b/samples/manager/test/manager.test.js
@@ -28,14 +28,14 @@ const region = 'us-central1';
 const projectId =
   process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
 
-const cmd = 'node manager/manager.js';
+const cmd = 'node manager.js';
 const cp = require('child_process');
 const cwd = path.join(__dirname, '..');
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const installDeps = 'npm install';
-const rsaPublicCert = 'resources/rsa_cert.pem'; // process.env.NODEJS_IOT_RSA_PUBLIC_CERT;
-const rsaPrivateKey = 'resources/rsa_private.pem'; //process.env.NODEJS_IOT_RSA_PRIVATE_KEY;
-const ecPublicKey = 'resources/ec_public.pem'; // process.env.NODEJS_IOT_EC_PUBLIC_KEY;
+const rsaPublicCert = '../resources/rsa_cert.pem'; // process.env.NODEJS_IOT_RSA_PUBLIC_CERT;
+const rsaPrivateKey = '../resources/rsa_private.pem'; //process.env.NODEJS_IOT_RSA_PRIVATE_KEY;
+const ecPublicKey = '../resources/ec_public.pem'; // process.env.NODEJS_IOT_EC_PUBLIC_KEY;
 
 const iotClient = new iot.v1.DeviceManagerClient();
 const pubSubClient = new PubSub({projectId});

--- a/samples/mqtt_example/package.json
+++ b/samples/mqtt_example/package.json
@@ -5,24 +5,28 @@
   "license": "Apache-2.0",
   "main": "cloudiot_mqtt_example_nodejs.js",
   "name": "nodejs-docs-samples-iot-mqtt-example",
+  "files": [
+    "*.js"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
+    "url": "https://github.com/googleapis/nodejs-iot.git"
   },
   "engines": {
     "node": ">=10.0.0"
   },
   "scripts": {
-    "test": "mocha system-test/*.test.js --timeout=600000",
-    "system-test": "mocha system-test/*.test.js --timeout=600000"
+    "test": "mocha --timeout=600000"
   },
   "dependencies": {
     "@google-cloud/iot": "^2.0.0",
     "@google-cloud/pubsub": "^2.0.0",
     "jsonwebtoken": "^8.5.0",
-    "mocha": "^8.0.0",
     "mqtt": "^4.0.0",
-    "yargs": "^15.0.0",
+    "yargs": "^15.0.0"
+  },
+  "devDependencies": {
+    "mocha": "^8.1.1",
     "uuid": "^8.0.0"
   }
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
   "repository": "googleapis/nodejs-iot",
   "private": true,
   "scripts": {
-    "test": "mocha --timeout 60000 manager/system-test/manager.test.js http_example/system-test/cloudiot_http_example.test.js mqtt_example/system-test/cloudiot_mqtt_example.test.js"
+    "test": "cd manager && npm test && cd ../ && cd http_example && npm test && cd ../ && cd mqtt_example && npm test && cd ../"
   },
   "dependencies": {
     "@google-cloud/iot": "^2.1.1",
@@ -22,11 +22,8 @@
     "chai": "^4.2.0",
     "hash_file": "^0.1.1",
     "jsonwebtoken": "^8.5.0",
-    "mocha": "^8.0.0",
+    "mocha": "^8.1.1",
     "mqtt": "^4.0.0",
-    "request": "^2.88.0",
-    "retry-request": "^4.0.0",
-    "tape": "^4.13.0",
     "uuid": "^8.0.0",
     "yargs": "^15.1.0"
   }


### PR DESCRIPTION
This does a few things:
- removes usage of `request`, which is deprecated
- moves several packages from `dependencies` to `devDependencies`
- cleans up the cwd for execution of specific sub-directories
